### PR TITLE
- updated debian repositories on geoserver Dockerfile

### DIFF
--- a/geoserver/Dockerfile
+++ b/geoserver/Dockerfile
@@ -10,7 +10,7 @@ ENV GEOSERVER_EXT_DIR /var/local/geoserver-exts
 ENV TOMCAT_INSTALL_DIR /usr/local/tomcat
 
 # Fonts
-RUN echo "deb http://httpredir.debian.org/debian stretch contrib" >> /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian stretch contrib" >> /etc/apt/sources.list
 RUN set -x \
     && apt-get update \
     && apt-get install -yq unzip \


### PR DESCRIPTION
On April 2023, [Stretch has been moved to archive.debian.org](https://unix.stackexchange.com/questions/743839/apt-get-update-failed-to-fetch-debian-amd64-packages-while-building-dockerfile-f)
This was causing the geoserver build to fail:
https://github.com/emotional-cities/openapi-sdi/issues/29